### PR TITLE
ci: add frontend and backend verification

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,97 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  frontend:
+    name: Frontend
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: frontend
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: Set up pnpm
+        uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
+
+      - name: Set up Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: "24"
+          cache: pnpm
+          cache-dependency-path: pnpm-lock.yaml
+
+      - name: Install frontend dependencies
+        run: pnpm install --frozen-lockfile
+        working-directory: .
+
+      - name: Check frontend formatting
+        run: pnpm run biome:check
+
+      - name: Lint frontend
+        run: pnpm run lint
+
+      - name: Type-check frontend
+        run: pnpm run typecheck
+
+      - name: Test frontend
+        run: pnpm run test
+
+      - name: Build frontend static export
+        run: pnpm run build
+
+      - name: Verify frontend static export
+        run: test -f out/index.html
+
+  backend:
+    name: Backend
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: backend
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: Set up uv and Python
+        uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
+        with:
+          version: "0.11.28"
+          python-version: "3.11"
+          working-directory: backend
+          enable-cache: true
+          cache-dependency-glob: uv.lock
+
+      - name: Install backend dependencies
+        run: uv sync --frozen
+
+      - name: Check backend formatting
+        run: uv run --frozen ruff format --check app tests
+
+      - name: Lint backend
+        run: uv run --frozen ruff check app tests
+
+      - name: Type-check backend
+        run: uv run --frozen pyright
+
+      - name: Test backend
+        run: uv run --frozen python -m pytest
+
+      - name: Compile backend
+        run: uv run --frozen python -m compileall -q app

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,7 @@ jobs:
   frontend:
     name: Frontend
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     defaults:
       run:
         working-directory: frontend
@@ -60,6 +61,7 @@ jobs:
   backend:
     name: Backend
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     defaults:
       run:
         working-directory: backend


### PR DESCRIPTION
## Summary

- add frontend and backend GitHub Actions verification
- pin third-party actions to immutable commits
- mirror the repository's exact formatting, lint, type-check, test, build, and compile commands
- verify the Next.js static export artifact

## Local verification

- `actionlint .github/workflows/ci.yml`
- `pnpm install --frozen-lockfile`
- `pnpm --dir frontend run biome:check`
- `pnpm --dir frontend run lint`
- `pnpm --dir frontend run typecheck`
- `pnpm --dir frontend run test` (12 tests)
- `pnpm --dir frontend run build`
- `test -f frontend/out/index.html`
- `uv sync --directory backend --frozen --python 3.11`
- `uv run --directory backend --frozen ruff format --check app tests`
- `uv run --directory backend --frozen ruff check app tests`
- `uv run --directory backend --frozen pyright`
- `uv run --directory backend --frozen python -m pytest` (1 test)
- `uv run --directory backend --frozen python -m compileall -q app`